### PR TITLE
fix compile errors (new Qt version)

### DIFF
--- a/click/docviewer-libs.json
+++ b/click/docviewer-libs.json
@@ -2,40 +2,10 @@
     "armhf": [
         {
             "url": "http://ports.ubuntu.com/ubuntu-ports",
-            "dist": "vivid",
+            "dist": "xenial",
             "component": "main",
-            "packages": [
-                "libboost-date-time1.55.0",
-                "libgl1-mesa-glx",
-                "libxcb-dri3-0",
-                "libxcb-glx0",
-                "libxcb-present0",
-                "libxshmfence1",
-                "libxslt1.1",
-                "libxt6",
-                "libxxf86vm1",
-                "gconf-service",
-                "gconf-service-backend",
-                "gconf2-common",
-                "libgconf-2-4"
-            ]
-        },
-        {
-            "url": "http://ppa.launchpad.net/canonical-community/ppa/ubuntu",
-            "dist": "vivid",
-            "component": "main",
-            "packages": [
-                "libreoffice-vanilla"
-            ]
-        }
-    ],
-
-    "i386": [
-        {
-            "url": "http://archive.ubuntu.com/ubuntu",
-            "dist": "vivid",
-            "component": "main",
-            "packages": [
+            "packages" : [],
+            "packages_": [
                 "libboost-date-time1.55.0",
                 "libgl1-mesa-glx",
                 "libxcb-dri3-0",
@@ -64,9 +34,10 @@
     "amd64": [
         {
             "url": "http://archive.ubuntu.com/ubuntu",
-            "dist": "vivid",
+            "dist": "xenial",
             "component": "main",
-            "packages": [
+            "packages" : [],
+            "packages_": [
                 "libboost-date-time1.55.0",
                 "libgl1-mesa-glx",
                 "libxcb-dri3-0",

--- a/cmake/modules/Click.cmake
+++ b/cmake/modules/Click.cmake
@@ -55,8 +55,13 @@ if(CLICK_MODE)
   MESSAGE("Following files to install:- ${FILES_TO_DEPLOY}")
   INSTALL( FILES ${FILES_TO_DEPLOY} DESTINATION ${DATA_DIR}lib/${ARCH_TRIPLET} )
 
-  MESSAGE("Installing LibreOffice from ${UPSTREAM_LIBS_DIR}/opt/libreoffice/lib/libreoffice to ${DATA_DIR}lib/${ARCH_TRIPLET}/libreoffice")
-  INSTALL( DIRECTORY ${UPSTREAM_LIBS_DIR}/opt/libreoffice/lib/libreoffice/ DESTINATION ${DATA_DIR}lib/${ARCH_TRIPLET}/libreoffice )
+  # if no line is active, docviewer is built without libreoffice support (plugin)
+  #MESSAGE("Installing LibreOffice from ${UPSTREAM_LIBS_DIR}/opt/libreoffice/lib/libreoffice to ${DATA_DIR}lib/${ARCH_TRIPLET}/libreoffice")
+  # original line (install downloaded deps) 
+  #INSTALL( DIRECTORY ${UPSTREAM_LIBS_DIR}/opt/libreoffice/lib/libreoffice/ DESTINATION ${DATA_DIR}lib/${ARCH_TRIPLET}/libreoffice )
+  # install deps from build environment (/usr/lib)
+  #INSTALL(DIRECTORY /usr/lib/libreoffice/ DESTINATION ${DATA_DIR}lib/${ARCH_TRIPLET}/libreoffice )
+
 else(CLICK_MODE)
   execute_process(
     COMMAND qmake -query QT_INSTALL_QML

--- a/src/plugin/poppler-qml-plugin/verticalview.cpp
+++ b/src/plugin/poppler-qml-plugin/verticalview.cpp
@@ -460,7 +460,7 @@ bool VerticalView::addVisibleItems(qreal fillFrom, qreal fillTo, bool asynchrono
     bool changed = false;
 
     while (modelIndex < m_delegateModel->count() && pos <= fillTo) {
-        if (!(item = createItem(modelIndex, asynchronous)))
+        if (!(item = createItem(modelIndex, asynchronous ? QQmlIncubator::Asynchronous : QQmlIncubator::AsynchronousIfNested)))
             break;
         pos += item->height() + m_spacing;
         ++modelIndex;
@@ -475,7 +475,7 @@ bool VerticalView::addVisibleItems(qreal fillFrom, qreal fillTo, bool asynchrono
         pos = item->y();
     }
     while (modelIndex >= 0 && pos > fillFrom) {
-        if (!(item = createItem(modelIndex, asynchronous)))
+        if (!(item = createItem(modelIndex, asynchronous ? QQmlIncubator::Asynchronous : QQmlIncubator::AsynchronousIfNested )))
             break;
         pos -= item->height() + m_spacing;
         --modelIndex;
@@ -558,7 +558,7 @@ VerticalView::ListItem *VerticalView::createItem(int modelIndex, bool asynchrono
         return nullptr;
 
     m_asyncRequestedIndex = -1;
-    QObject* object = m_delegateModel->object(modelIndex, asynchronous);
+    QObject* object = m_delegateModel->object(modelIndex, asynchronous ? QQmlIncubator::Asynchronous : QQmlIncubator::AsynchronousIfNested);
     QQuickItem *item = qmlobject_cast<QQuickItem*>(object);
     if (!item) {
         if (object) {
@@ -753,11 +753,11 @@ void VerticalView::_q_modelUpdated(const QQmlChangeSet &changeSet, bool /*reset*
     m_contentHeightDirty = true;
 }
 
-void VerticalView::itemGeometryChanged(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
+void VerticalView::itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &oldGeometry)
 {
-    const qreal heightDiff = newGeometry.height() - oldGeometry.height();
-    if (heightDiff != 0) {
+    if (change.heightChange()) {
         if (oldGeometry.y() + oldGeometry.height() <= contentY() && !m_visibleItems.isEmpty()) {
+            const qreal heightDiff = height() - oldGeometry.height();
             ListItem *firstItem = m_visibleItems.first();
             firstItem->setY(firstItem->y() - heightDiff);
             adjustMinYExtent();

--- a/src/plugin/poppler-qml-plugin/verticalview.cpp
+++ b/src/plugin/poppler-qml-plugin/verticalview.cpp
@@ -460,8 +460,14 @@ bool VerticalView::addVisibleItems(qreal fillFrom, qreal fillTo, bool asynchrono
     bool changed = false;
 
     while (modelIndex < m_delegateModel->count() && pos <= fillTo) {
+        #if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+        if (!(item = createItem(modelIndex, asynchronous)))
+        #else
         if (!(item = createItem(modelIndex, asynchronous ? QQmlIncubator::Asynchronous : QQmlIncubator::AsynchronousIfNested)))
+        #endif
+        {
             break;
+        }
         pos += item->height() + m_spacing;
         ++modelIndex;
         changed = true;
@@ -475,8 +481,14 @@ bool VerticalView::addVisibleItems(qreal fillFrom, qreal fillTo, bool asynchrono
         pos = item->y();
     }
     while (modelIndex >= 0 && pos > fillFrom) {
-        if (!(item = createItem(modelIndex, asynchronous ? QQmlIncubator::Asynchronous : QQmlIncubator::AsynchronousIfNested )))
+        #if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+        if (!(item = createItem(modelIndex, asynchronous)))
+        #else
+        if (!(item = createItem(modelIndex, asynchronous ? QQmlIncubator::Asynchronous : QQmlIncubator::AsynchronousIfNested)))
+        #endif
+        {
             break;
+        }
         pos -= item->height() + m_spacing;
         --modelIndex;
         changed = true;
@@ -558,7 +570,12 @@ VerticalView::ListItem *VerticalView::createItem(int modelIndex, bool asynchrono
         return nullptr;
 
     m_asyncRequestedIndex = -1;
+    #if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+    QObject* object = m_delegateModel->object(modelIndex, asynchronous);
+    #else
     QObject* object = m_delegateModel->object(modelIndex, asynchronous ? QQmlIncubator::Asynchronous : QQmlIncubator::AsynchronousIfNested);
+    #endif
+            
     QQuickItem *item = qmlobject_cast<QQuickItem*>(object);
     if (!item) {
         if (object) {
@@ -753,6 +770,23 @@ void VerticalView::_q_modelUpdated(const QQmlChangeSet &changeSet, bool /*reset*
     m_contentHeightDirty = true;
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+void VerticalView::itemGeometryChanged(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
+{
+    const qreal heightDiff = newGeometry.height() - oldGeometry.height();
+    if (heightDiff != 0) {
+        if (oldGeometry.y() + oldGeometry.height() <= contentY() && !m_visibleItems.isEmpty()) {
+            ListItem *firstItem = m_visibleItems.first();
+            firstItem->setY(firstItem->y() - heightDiff);
+            adjustMinYExtent();
+            layout();
+        }
+        refill();
+        adjustMinYExtent();
+        polish();
+        m_contentHeightDirty = true;
+    }
+#else
 void VerticalView::itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &oldGeometry)
 {
     if (change.heightChange()) {
@@ -769,6 +803,7 @@ void VerticalView::itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChan
         m_contentHeightDirty = true;
     }
 }
+#endif
 
 void VerticalView::adjustMinYExtent()
 {

--- a/src/plugin/poppler-qml-plugin/verticalview.h
+++ b/src/plugin/poppler-qml-plugin/verticalview.h
@@ -93,7 +93,11 @@ protected:
     void componentComplete() override;
     void viewportMoved(Qt::Orientations orient) override;
     qreal minYExtent() const override;
+    #if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+    void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    #else
     void itemGeometryChanged(QQuickItem *item, QQuickGeometryChange change, const QRectF &oldGeometry) override;
+    #endif
     void updatePolish() override;
 
 private Q_SLOTS:

--- a/src/plugin/poppler-qml-plugin/verticalview.h
+++ b/src/plugin/poppler-qml-plugin/verticalview.h
@@ -93,7 +93,7 @@ protected:
     void componentComplete() override;
     void viewportMoved(Qt::Orientations orient) override;
     qreal minYExtent() const override;
-    void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    void itemGeometryChanged(QQuickItem *item, QQuickGeometryChange change, const QRectF &oldGeometry) override;
     void updatePolish() override;
 
 private Q_SLOTS:

--- a/tests/autopilot/ubuntu_docviewer_app/__init__.py
+++ b/tests/autopilot/ubuntu_docviewer_app/__init__.py
@@ -44,3 +44,4 @@ class MainView(ubuntuuitoolkit.MainView):
     def __init__(self, *args):
         super(MainView, self).__init__(*args)
         self.visible.wait_for(True)
+


### PR DESCRIPTION
-  QmlIncubator::Asynchronous for boolean "asynchronous" parameter

I used `asynchronous ? QQmlIncubator::Asynchronous : QQmlIncubator::AsynchronousIfNested`, another possibility would be `asynchronous ? QQmlIncubator::Asynchronous : QQmlIncubator::Synchronous` (see https://doc.qt.io/qt-5/qqmlincubator.html#IncubationMode-enum)
AsynchronousIfNested sounded reasonable to me...

- overloaded itemGeometryChanged interface changed with new Qt version
(this one is similar to the change https://github.com/ubports/unity8/commit/5aa12faa43f6a2fb1e8d0c68945feee3721010a5#diff-4e3ae275386e790f3de312ee49f50be2)

[edit: commented, not uncommented : )]
this PR fixes the build errors, for building it with clickable I commented out the line
```
INSTALL(DIRECTORY ${UPSTREAM_LIBS_DIR}/opt/libreoffice/lib/libreoffice/ DESTINATION ${DATA_DIR}lib/${ARCH_TRIPLET}/libreoffice )
```
in ./cmake/modules/Click.cmake
and used
```
{
"dependencies" : ["libpoppler-qt5-dev", "curl"]
}
```
as clickable.json file

I've seen the build downloads "libreoffice-vanilla" from http://ppa.launchpad.net/canonical-community/ppa/ubuntu/pool/main/libr/libreoffice-vanilla/  not sure what has to be done about that for xenial...